### PR TITLE
修正了编译镜像过程中无法正确获取build version的报错问题

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY . .
 
 RUN set -ex \
     && apk add git \
-    && export BUILD_VERSION=$(cat version) \
+    && export BUILD_VERSION=$(cat /proc/version) \
     && export BUILD_DATE=$(date "+%F %T") \
     && export COMMIT_SHA1=$(git rev-parse HEAD) \
     && go install -ldflags \


### PR DESCRIPTION
Following the instructions for building docker images, there would be an error message:
```bash
cat: version: No such file or directory
```
I have fixed it by the correct cmd:
```bash
cat /proc/version
```